### PR TITLE
Remove Views UI from profile dependencies

### DIFF
--- a/headless_lightning.info.yml
+++ b/headless_lightning.info.yml
@@ -26,3 +26,4 @@ base profile:
   - lightning_page
   - lightning_search
   - lightning_landing_page
+  - views_ui


### PR DESCRIPTION
Views UI is a developer tool and there's no real need for it out of the box in a headless distro. Let's ice it.