### PR TITLE
Clean up entity form redirection code

### DIFF
--- a/modules/headless_ui/headless_ui.module
+++ b/modules/headless_ui/headless_ui.module
@@ -1,8 +1,8 @@
 <?php
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element as RenderElement;
-use Drupal\lightning_core\Element;
+use Drupal\Core\Render\Element;
+use Drupal\headless_ui\Redirect;
 use Drupal\node\NodeTypeInterface;
 use Drupal\views\ViewEntityInterface;
 
@@ -13,90 +13,61 @@ function headless_ui_view_presave(ViewEntityInterface $view) {
   if (\Drupal::isConfigSyncing()) {
     return;
   }
-  if ($view->id() == 'content' && $view->isNew()) {
+  elseif ($view->isNew()) {
     $display = &$view->getDisplay('default');
 
     $fields = &$display['display_options']['fields'];
-    if (isset($fields['title'])) {
-      // Add the node ID as a hidden field at the top of the list, if it doesn't
-      // already exist, so we can use it as a token in the title field.
-      if (empty($fields['nid'])) {
-        $keys = array_keys($fields);
-        array_unshift($keys, 'nid');
-        $fields['nid'] = unserialize('a:37:{s:2:"id";s:3:"nid";s:5:"table";s:15:"node_field_data";s:5:"field";s:3:"nid";s:12:"relationship";s:4:"none";s:10:"group_type";s:5:"group";s:11:"admin_label";s:0:"";s:5:"label";s:2:"ID";s:7:"exclude";b:1;s:5:"alter";a:26:{s:10:"alter_text";b:0;s:4:"text";s:0:"";s:9:"make_link";b:0;s:4:"path";s:0:"";s:8:"absolute";b:0;s:8:"external";b:0;s:14:"replace_spaces";b:0;s:9:"path_case";s:4:"none";s:15:"trim_whitespace";b:0;s:3:"alt";s:0:"";s:3:"rel";s:0:"";s:10:"link_class";s:0:"";s:6:"prefix";s:0:"";s:6:"suffix";s:0:"";s:6:"target";s:0:"";s:5:"nl2br";b:0;s:10:"max_length";i:0;s:13:"word_boundary";b:1;s:8:"ellipsis";b:1;s:9:"more_link";b:0;s:14:"more_link_text";s:0:"";s:14:"more_link_path";s:0:"";s:10:"strip_tags";b:0;s:4:"trim";b:0;s:13:"preserve_tags";s:0:"";s:4:"html";b:0;}s:12:"element_type";s:0:"";s:13:"element_class";s:0:"";s:18:"element_label_type";s:0:"";s:19:"element_label_class";s:0:"";s:19:"element_label_colon";b:1;s:20:"element_wrapper_type";s:0:"";s:21:"element_wrapper_class";s:0:"";s:23:"element_default_classes";b:1;s:5:"empty";s:0:"";s:10:"hide_empty";b:0;s:10:"empty_zero";b:0;s:16:"hide_alter_empty";b:1;s:17:"click_sort_column";s:5:"value";s:4:"type";s:14:"number_integer";s:8:"settings";a:2:{s:18:"thousand_separator";s:0:"";s:13:"prefix_suffix";b:1;}s:12:"group_column";s:5:"value";s:13:"group_columns";a:0:{}s:10:"group_rows";b:1;s:11:"delta_limit";i:0;s:12:"delta_offset";i:0;s:14:"delta_reversed";b:0;s:16:"delta_first_last";b:0;s:10:"multi_type";s:9:"separator";s:9:"separator";s:2:", ";s:17:"field_api_classes";b:0;s:11:"entity_type";s:4:"node";s:12:"entity_field";s:3:"nid";s:9:"plugin_id";s:5:"field";}');
-        Element::order($fields, $keys);
-      }
 
-      $fields['title']['settings']['link_to_entity'] = FALSE;
-      $fields['title']['alter']['make_link'] = TRUE;
-      $fields['title']['alter']['path'] = '/node/{{ nid }}/edit?destination=/admin/content';
+    switch ($view->id()) {
+      case 'content':
+        if (isset($fields['title'])) {
+          $fields['title']['settings']['link_to_entity'] = FALSE;
+        }
+        if (isset($fields['name'])) {
+          $fields['name']['settings']['link_to_entity'] = FALSE;
+        }
+        break;
+
+      case 'media':
+        if (isset($fields['name'])) {
+          $fields['name']['settings']['link_to_entity'] = FALSE;
+        }
+        if (isset($fields['uid'])) {
+          $fields['uid']['settings']['link_to_entity'] = FALSE;
+        }
+        break;
+
+      case 'user_admin_people':
+        if (isset($fields['name'])) {
+          $fields['name']['settings']['link_to_entity'] = FALSE;
+        }
+        break;
+
+      default:
+        break;
     }
-  }
-  if ($view->id() == 'media' && $view->isNew()) {
-    $display = &$view->getDisplay('default');
-
-    $fields = &$display['display_options']['fields'];
-    if (isset($fields['name'])) {
-      // Add the media ID as a hidden field at the top of the list, if it
-      // doesn't already exist, so we can use it as a token in the name field.
-      if (empty($fields['mid'])) {
-        $keys = array_keys($fields);
-        array_unshift($keys, 'mid');
-        $fields['mid'] = unserialize('a:37:{s:2:"id";s:3:"mid";s:5:"table";s:16:"media_field_data";s:5:"field";s:3:"mid";s:12:"relationship";s:4:"none";s:10:"group_type";s:5:"group";s:11:"admin_label";s:0:"";s:5:"label";s:8:"Media ID";s:7:"exclude";b:1;s:5:"alter";a:26:{s:10:"alter_text";b:0;s:4:"text";s:0:"";s:9:"make_link";b:0;s:4:"path";s:0:"";s:8:"absolute";b:0;s:8:"external";b:0;s:14:"replace_spaces";b:0;s:9:"path_case";s:4:"none";s:15:"trim_whitespace";b:0;s:3:"alt";s:0:"";s:3:"rel";s:0:"";s:10:"link_class";s:0:"";s:6:"prefix";s:0:"";s:6:"suffix";s:0:"";s:6:"target";s:0:"";s:5:"nl2br";b:0;s:10:"max_length";i:0;s:13:"word_boundary";b:1;s:8:"ellipsis";b:1;s:9:"more_link";b:0;s:14:"more_link_text";s:0:"";s:14:"more_link_path";s:0:"";s:10:"strip_tags";b:0;s:4:"trim";b:0;s:13:"preserve_tags";s:0:"";s:4:"html";b:0;}s:12:"element_type";s:0:"";s:13:"element_class";s:0:"";s:18:"element_label_type";s:0:"";s:19:"element_label_class";s:0:"";s:19:"element_label_colon";b:1;s:20:"element_wrapper_type";s:0:"";s:21:"element_wrapper_class";s:0:"";s:23:"element_default_classes";b:1;s:5:"empty";s:0:"";s:10:"hide_empty";b:0;s:10:"empty_zero";b:0;s:16:"hide_alter_empty";b:1;s:17:"click_sort_column";s:5:"value";s:4:"type";s:14:"number_integer";s:8:"settings";a:2:{s:18:"thousand_separator";s:0:"";s:13:"prefix_suffix";b:1;}s:12:"group_column";s:5:"value";s:13:"group_columns";a:0:{}s:10:"group_rows";b:1;s:11:"delta_limit";i:0;s:12:"delta_offset";i:0;s:14:"delta_reversed";b:0;s:16:"delta_first_last";b:0;s:10:"multi_type";s:9:"separator";s:9:"separator";s:2:", ";s:17:"field_api_classes";b:0;s:11:"entity_type";s:5:"media";s:12:"entity_field";s:3:"mid";s:9:"plugin_id";s:5:"field";}');
-        Element::order($fields, $keys);
-      }
-
-      $fields['name']['settings']['link_to_entity'] = FALSE;
-      $fields['name']['alter']['make_link'] = TRUE;
-      $fields['name']['alter']['path'] = '/media/{{ mid }}/edit?destination=/admin/content/media';
-    }
-  }
-  if ($view->id() == 'user_admin_people' && $view->isNew()) {
-    $display = &$view->getDisplay('default');
-
-    $fields = &$display['display_options']['fields'];
-    if (isset($fields['name'])) {
-      // Add the user ID as a hidden field at the top of the list, if it
-      // doesn't already exist, so we can use it as a token in the name field.
-      if (empty($fields['uid'])) {
-        $keys = array_keys($fields);
-        array_unshift($keys, 'uid');
-        $fields['uid'] = unserialize('a:37:{s:2:"id";s:3:"uid";s:5:"table";s:16:"users_field_data";s:5:"field";s:3:"uid";s:12:"relationship";s:4:"none";s:10:"group_type";s:5:"group";s:11:"admin_label";s:0:"";s:5:"label";s:7:"User ID";s:7:"exclude";b:1;s:5:"alter";a:26:{s:10:"alter_text";b:0;s:4:"text";s:0:"";s:9:"make_link";b:0;s:4:"path";s:0:"";s:8:"absolute";b:0;s:8:"external";b:0;s:14:"replace_spaces";b:0;s:9:"path_case";s:4:"none";s:15:"trim_whitespace";b:0;s:3:"alt";s:0:"";s:3:"rel";s:0:"";s:10:"link_class";s:0:"";s:6:"prefix";s:0:"";s:6:"suffix";s:0:"";s:6:"target";s:0:"";s:5:"nl2br";b:0;s:10:"max_length";i:0;s:13:"word_boundary";b:1;s:8:"ellipsis";b:1;s:9:"more_link";b:0;s:14:"more_link_text";s:0:"";s:14:"more_link_path";s:0:"";s:10:"strip_tags";b:0;s:4:"trim";b:0;s:13:"preserve_tags";s:0:"";s:4:"html";b:0;}s:12:"element_type";s:0:"";s:13:"element_class";s:0:"";s:18:"element_label_type";s:0:"";s:19:"element_label_class";s:0:"";s:19:"element_label_colon";b:1;s:20:"element_wrapper_type";s:0:"";s:21:"element_wrapper_class";s:0:"";s:23:"element_default_classes";b:1;s:5:"empty";s:0:"";s:10:"hide_empty";b:0;s:10:"empty_zero";b:0;s:16:"hide_alter_empty";b:1;s:17:"click_sort_column";s:5:"value";s:4:"type";s:14:"number_integer";s:8:"settings";a:2:{s:18:"thousand_separator";s:0:"";s:13:"prefix_suffix";b:1;}s:12:"group_column";s:5:"value";s:13:"group_columns";a:0:{}s:10:"group_rows";b:1;s:11:"delta_limit";i:0;s:12:"delta_offset";i:0;s:14:"delta_reversed";b:0;s:16:"delta_first_last";b:0;s:10:"multi_type";s:9:"separator";s:9:"separator";s:2:", ";s:17:"field_api_classes";b:0;s:11:"entity_type";s:4:"user";s:12:"entity_field";s:3:"uid";s:9:"plugin_id";s:5:"field";}');
-        Element::order($fields, $keys);
-      }
-
-      $fields['name']['settings']['link_to_entity'] = FALSE;
-      $fields['name']['alter']['make_link'] = TRUE;
-      $fields['name']['alter']['path'] = '/user/{{ uid }}/edit?destination=/admin/people';
-    }
-  }
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function headless_ui_form_taxonomy_overview_terms_alter(array &$form, FormStateInterface $form_state) {
-  $build_info = $form_state->getBuildInfo();
-
-  $url_options = [];
-  $url_options['query']['destination'] = $build_info['args'][0]->toUrl('overview-form')->getInternalPath();
-
-  foreach (RenderElement::children($form['terms']) as $key) {
-    /** @var \Drupal\taxonomy\TermInterface $term */
-    $form['terms'][$key]['term']['#url'] = $form['terms'][$key]['#term']->toUrl('edit-form', $url_options);
   }
 }
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
-function headless_ui_form_node_form_alter(array &$form) {
-  $form['#submit'][] = 'headless_ui_redirect_node_form';
-  $form['actions']['submit']['#submit'][] = 'headless_ui_redirect_node_form';
+function headless_ui_form_node_form_alter(array &$form, FormStateInterface $form_state) {
+  Redirect::entityForm($form, $form_state);
 }
 
-function headless_ui_redirect_node_form(array &$form, FormStateInterface $form_state) {
-  $form_state->setRedirect('view.content.page_1');
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function headless_ui_form_media_form_alter(array &$form, FormStateInterface $form_state) {
+  Redirect::entityForm($form, $form_state);
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function headless_ui_form_user_form_alter(array &$form, FormStateInterface $form_state) {
+  Redirect::entityForm($form, $form_state);
 }
 
 /**
@@ -143,4 +114,16 @@ function headless_ui_process_node_type_workflow_options(array $element) {
   $element['promote']['#access'] = FALSE;
   $element['sticky']['#access'] = FALSE;
   return $element;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function headless_ui_form_taxonomy_overview_terms_alter(array &$form) {
+  foreach (Element::children($form['terms']) as $key) {
+    $term = &$form['terms'][$key]['term'];
+
+    $term['#type'] = 'markup';
+    $term['#markup'] = $term['#title'];
+  }
 }

--- a/modules/headless_ui/src/Redirect.php
+++ b/modules/headless_ui/src/Redirect.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\headless_ui;
+
+use Doctrine\Common\Inflector\Inflector;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+class Redirect {
+
+  public static function entityForm(array &$form, FormStateInterface $form_state) {
+    /** @var \Drupal\Core\Entity\EntityFormInterface $form_object */
+    $form_object = $form_state->getFormObject();
+
+    $redirect = [
+      static::class,
+      Inflector::camelize($form_object->getBaseFormId()),
+    ];
+
+    if (is_callable($redirect)) {
+      static::applyHandler($form['actions'], $redirect);
+    }
+  }
+
+  /**
+   * @TODO Make this public in \Drupal\lightning\FormHelper.
+   */
+  protected static function applyHandler(array &$actions, callable $handler, $handler_type = '#submit') {
+    foreach (Element::children($actions) as $key) {
+      if (isset($actions[$key][$handler_type])) {
+        $actions[$key][$handler_type][] = $handler;
+      }
+    }
+  }
+
+  public static function nodeForm(array &$form, FormStateInterface $form_state) {
+    $form_state->setRedirect('view.content.page_1');
+  }
+
+  public static function mediaForm(array &$form, FormStateInterface $form_state) {
+    $form_state->setRedirect('view.media.media_page_list');
+  }
+
+  public static function userForm(array &$form, FormStateInterface $form_state) {
+    $form_state->setRedirect('view.user_admin_people.page_1');
+  }
+
+}

--- a/tests/behat/features/redirects.feature
+++ b/tests/behat/features/redirects.feature
@@ -1,0 +1,73 @@
+@api @headless
+Feature: Entity form redirections
+
+  Scenario: Creating content as an administrator
+    Given I am logged in as a user with the administrator role
+    When I click "Content"
+    And I click "Add content"
+    And I enter "---TESTING---" for "Title"
+    And I press "Save"
+    Then I should be on "/admin/content"
+    # TODO: Restore when Lightning sets success_message_selector in behat.yml.
+    # And I should see the success message "Basic page ---TESTING--- has been created."
+
+  Scenario: Editing content as an administrator
+    Given I am logged in as a user with the administrator role
+    When I click "Content"
+    And I click "Add content"
+    And I enter "---TESTING---" for "Title"
+    And I press "Save"
+    And I click "Edit"
+    And I press "Save"
+    Then I should be on "/admin/content"
+    # TODO: Restore when Lightning sets success_message_selector in behat.yml.
+    # And I should see the success message "Basic page ---TESTING--- has been updated."
+
+  Scenario: Creating media as an administrator
+    Given I am logged in as a user with the administrator role
+    When I click "Content"
+    And I click "Media"
+    And I click "Add media"
+    And I click "Video"
+    And I enter "---TESTING---" for "Media name"
+    And I enter "https://www.youtube.com/watch?v=N2_HkWs7OM0" for "Video URL"
+    And I press "Save and publish"
+    Then I should be on "/admin/content/media"
+    # TODO: Restore when Lightning sets success_message_selector in behat.yml.
+    # And I should see the success message "Video ---TESTING--- has been created."
+
+  Scenario: Editing media as an administrator
+    Given I am logged in as a user with the administrator role
+    When I click "Content"
+    And I click "Media"
+    And I click "Add media"
+    And I click "Video"
+    And I enter "---TESTING---" for "Media name"
+    And I enter "https://www.youtube.com/watch?v=N2_HkWs7OM0" for "Video URL"
+    And I press "Save and publish"
+    And I click "Edit"
+    And I press "Save and keep published"
+    Then I should be on "/admin/content/media"
+    # TODO: Restore when Lightning sets success_message_selector in behat.yml.
+    # And I should see the success message "Video ---TESTING--- has been updated."
+
+  Scenario: Creating a user account as an administrator
+    Given I am logged in as a user with the administrator role
+    When I click "People"
+    And I click "Add user"
+    And I enter "---TESTING---" for "Username"
+    And I enter "---TESTING---" for "Password"
+    And I enter "---TESTING---" for "Confirm password"
+    And I press "Create new account"
+    Then I should be on "/admin/people"
+    # TODO: Restore when Lightning sets success_message_selector in behat.yml.
+    # And I should see the success message containing "Created a new user account for ---TESTING---."
+
+  Scenario: Editing a user account as an administrator
+    Given I am logged in as a user with the administrator role
+    When I click "People"
+    And I click "Edit"
+    And I press "Save"
+    Then I should be on "/admin/people"
+    # TODO: Restore when Lightning sets success_message_selector in behat.yml.
+    # And I should see the success message "The changes have been saved."


### PR DESCRIPTION
This PR does two overarching things:

1) From the admin views for nodes, media, and users (taxonomy terms are not using a view for administrative purposes), it removes any links to the canonical entity or the edit form. You can only edit the items via the Edit operation in the drop button. This is FAR simpler and less wonkiness-prone than trying to rewrite the link generated by the view (as I was doing previously), although this also imposes a stronger UX opinion.

2) Redirecting back to the administrative views is now done by submit handlers attached to the entity forms, rather than rewriting the links (which was a more brittle approach). No redirect handling is needed for Taxonomy, since it does the right thing anyway. I also refactored the relevant code, for cleanliness.