### PR TITLE
Don't set config in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ install:
   # Import the fixture and update from it, if it exists.
   - lightning update $VERSION
   - drush cache:rebuild
-  - drush config:set moderation_dashboard.settings redirect_on_login 1 --yes
 
 before_script:
   - cd $TRAVIS_BUILD_DIR/docroot


### PR DESCRIPTION
While "Moderation dashboard" is not installed by Lightning, we shouldn't set its config with drush.
The module will be enabled in https://github.com/acquia/lightning/pull/621
